### PR TITLE
testing torch==1.13.1+cu117 and torchvision==0.14.1+cu117 on 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,10 @@ jobs:
             python-version: '3.8'
             cuda-version: '11.7.0'
             torch-install-command: 'torch==1.13.0+cu117 torchvision==0.14.0+cu117 --extra-index-url https://download.pytorch.org/whl/cu117'
+          - os-version: windows-latest
+            python-version: '3.10'
+            cuda-version: '11.7.0'
+            torch-install-command: 'torch==1.13.1+cu117 torchvision==0.14.1+cu117 --extra-index-url https://download.pytorch.org/whl/cu117'
 
     steps:
       - uses: actions/setup-python@v4


### PR DESCRIPTION
Disclaimer: I don't really know enough about this.

Just thought I'd give it a go in case this is helpful in any way, if not feel free to close this PR.

The build I added [seems to have completed successfully on my test branch](https://github.com/petalas/xfromers_builds/actions/runs/3761898149/jobs/6394076435).

Interestingly 2 of the existing ones failed? [This one](https://github.com/petalas/xfromers_builds/actions/runs/3761898149/jobs/6394076196) and [this one](https://github.com/petalas/xfromers_builds/actions/runs/3761898149/jobs/6394076246).

Is this how you'd create a cu117 build for python 3.10?
Hoping we can use it with Automatic1111's webui.